### PR TITLE
Rename silinternational to sil-org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sil-org/php-devs

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022 SIL International
+Copyright (c) 2022 SIL Global
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "silinternational/zxcvbn-api-client-php",
+  "name": "sil-org/zxcvbn-api-client-php",
   "type": "library",
   "description": "PHP client library for interacting with Zxcvbn API. See https://github.com/wcjr/zxcvbn-api",
   "keywords": ["zxcvbn"],


### PR DESCRIPTION
### Changed
- Rename silinternational to sil-org
- Rename SIL International to SIL Global
- Added CODEOWNERS file